### PR TITLE
make compatible with version > 11 of xmlbuilder

### DIFF
--- a/lib/sitemap-item.ts
+++ b/lib/sitemap-item.ts
@@ -78,7 +78,7 @@ class SitemapItem {
   root: builder.XMLElementOrXMLNode;
   url: builder.XMLElementOrXMLNode & {
     children?: [],
-    attributes?: {}
+    attribs?: {}
   };
 
   constructor (conf: SitemapItemOptions = {}) {
@@ -248,7 +248,7 @@ class SitemapItem {
 
   buildXML (): builder.XMLElementOrXMLNode {
     this.url.children = []
-    this.url.attributes = {}
+    this.url.attribs = {}
     // xml property
     const props = ['loc', 'lastmod', 'changefreq', 'priority', 'img', 'video', 'links', 'expires', 'androidLink', 'mobile', 'news', 'ampLink'] as const;
     // property array size (for loop)

--- a/lib/sitemap.ts
+++ b/lib/sitemap.ts
@@ -49,7 +49,7 @@ export class Sitemap {
   xslUrl: string
   xmlNs: string
   root: builder.XMLElementOrXMLNode & {
-    attributes?: [],
+    attribs?: [],
     children?: [],
 
     instructionBefore?(...argv)
@@ -187,8 +187,8 @@ export class Sitemap {
    *  @return {String}
    */
   toString() {
-    if (this.root.attributes.length) {
-      this.root.attributes = []
+    if (this.root.attribs.length) {
+      this.root.attribs = []
     }
     if (this.root.children.length) {
       this.root.children = []

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "lodash": "^4.17.11",
     "url-join": "^4.0.0",
-    "xmlbuilder": "^12.0.1"
+    "xmlbuilder": "^13.0.0"
   },
   "devDependencies": {
     "@bluelovers/tsconfig": "^1.0.3",


### PR DESCRIPTION
@bluelovers this applies the changes from my open PR https://github.com/ekalinin/sitemap.js/pull/184/files#diff-4790ad69aa3c31a12f9a29774ea6157fL220 that will fix the failing unit tests. 
I'm not sure what command you are using to generate the JS files so you will need to run that command again and check in the code before this will work.